### PR TITLE
Rename environment variable to "HCLOUD_VOLUME_DEFAULT_LOCATION"

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -29,12 +29,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	metadataClient := metadata.NewClient(metadata.WithInstrumentation(m.Registry()))
 	var location string
 
-	if s := os.Getenv("HCLOUD_SERVER_OVERRIDE_LOCATION_NAME"); s != "" {
+	if s := os.Getenv("HCLOUD_VOLUME_DEFAULT_LOCATION"); s != "" {
 		location = s
 	} else {
+		metadataClient := metadata.NewClient(metadata.WithInstrumentation(m.Registry()))
+
 		server, err := app.GetServer(logger, hcloudClient, metadataClient)
 		if err != nil {
 			level.Error(logger).Log(


### PR DESCRIPTION
As requested by @apricote upstream rename the environment variable `HCLOUD_SERVER_OVERRIDE_LOCATION_NAME` to `HCLOUD_VOLUME_DEFAULT_LOCATION` as well as move the `metadataClient` to the `else` branch.